### PR TITLE
Update UnityEditorShell.cs

### DIFF
--- a/Editor/Core/UnityEditorShell.cs
+++ b/Editor/Core/UnityEditorShell.cs
@@ -110,7 +110,7 @@ namespace UnityShell.Editor
             #if UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX
             processStartInfo.Arguments = "-c";
             #elif UNITY_EDITOR_WIN
-            start.Arguments = "/c";
+            processStartInfo.Arguments = "/c";
             #endif
 
             if (options.EnvironmentVariables != null)


### PR DESCRIPTION
"UnityEditorShell.cs(112,13): error CS0103: The name 'start' does not exist in the current context"

Making the proposed change allows your example code to run properly in Unity 2022.3.22f1